### PR TITLE
Add more sanity checks and fix size formatting in ls example (#11)

### DIFF
--- a/examples/ls.rs
+++ b/examples/ls.rs
@@ -14,14 +14,14 @@ fn format_file_size(size: u64) -> String {
     const KB: u64 = 1024;
     const MB: u64 = 1024 * KB;
     const GB: u64 = 1024 * MB;
-    if size < 1024 {
+    if size < KB {
         format!("{}B", size)
     } else if size < MB {
         format!("{}KB", size / KB)
     } else if size < GB {
-        format!("{}KB", size / MB)
+        format!("{}MB", size / MB)
     } else {
-        format!("{}KB", size / GB)
+        format!("{}GB", size / GB)
     }
 }
 


### PR DESCRIPTION
* Fix copy/paste errors in ls example so file sizes are correctly output.
* BPB updates.

Fix bug in bpb.active_fat(), because active_fat is
only valid when mirroring is disabled.

Add additional santiy checks to BPB deserialization:
1. bytes per sector must be a power of 2
2. 512 <= bytes per sector <= 4096
3. sectors per cluster must be a power of 2
4. 1 <= sectors per cluster <= 128

Also added some comments relating to conditions that
may be useful to WARN about for BPB deserialization:
Z. bpb.reserved_sectors should be 1
Y. bpb.fats should be either 1 or 2
X. bpb.fs_version should be validated as zero

Add syntactic sugar for:
A. bpb.is_fat32()
B. bpb.sectors_per_fat()
C. bpb.total_sectors()